### PR TITLE
ellipsis passed to mirror_brain in mirror_manc

### DIFF
--- a/R/xform.R
+++ b/R/xform.R
@@ -50,7 +50,7 @@ mirror_manc <- function(x, level=c(5,4), ...) {
   mirror_reg_f=mirror_manc_reglist(level = level)
   mirror_reg_r=mirror_manc_reglist("reverse", level = level)
   xt=xform(x, reg=mirror_reg_f, ... )
-  xtm=mirror_brain(xt, brain = MANCsym, mirrorAxis = 'X', transform='flip')
+  xtm=mirror_brain(xt, brain = MANCsym, mirrorAxis = 'X', transform='flip', ...)
   xtmt=xform(xtm, reg=mirror_reg_r, ... )
   xtmt
 }


### PR DESCRIPTION
Minor fix, that addresses passing extra parameters to `mirror_brain`. FIxes for instance subsetting:

```r
mirr_tstnrns <- mirror_manc(tstnrns, subset=grepl("_L", tstnrns[,'name']))
```