### PR TITLE
updatebodyids - backward compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: malevnc
 Title: Support for Working with Janelia FlyEM Male VNC Dataset
-Version: 0.1.1
+Version: 0.1.2
 Authors@R:
     c(person(given = "Gregory",
            family = "Jefferis",
@@ -55,7 +55,7 @@ Enhances:
 URL: https://github.com/flyconnectome/malevnc
 BugReports: https://github.com/flyconnectome/malevnc/issues
 Depends: 
-    R (>= 2.10)
+    R (>= 3.6.0)
 Remotes: 
     natverse/nat,
     natverse/neuprintr,

--- a/R/annotations.R
+++ b/R/annotations.R
@@ -312,9 +312,11 @@ updatebodyids <- function(x, update=TRUE, cache=FALSE, add_auto=TRUE) {
       x$auto=TRUE
     } else {
       empty_field <- function(x) {
-        res=apply(x, 2, simplify = FALSE, function(y) {
-          if(is.list(y)) is.na(y) | lengths(y)==0 else is.na(y)
-          })
+        res = lapply(1:ncol(x), function(ny) {
+           y = x[,ny]
+           if(is.list(y)) is.na(y) | lengths(y)==0 else is.na(y)
+         })
+        names(res) <- colnames(x)
         as.data.frame(res)
       }
       rs=rowSums(empty_field(x[, manualfields, drop=F]))


### PR DESCRIPTION
Workaround to avoid simplification with `lapply` columnwise.

I changed the R version to `3.6.0` as this is the earliest we can test things at (via Lisa).