### PR TITLE
Add clio new fields annotation check

### DIFF
--- a/R/annotate.R
+++ b/R/annotate.R
@@ -251,7 +251,10 @@ parse_query <- function(query, version) {
 #'   \bold{NB only applies when \code{x} is a data.frame}.
 #' @param query Special query to pass to Clio API. If TRUE, then the default is
 #'   passed with Clio version, FALSE means no query, and list is allowed for a
-#'   customized behavior.
+#'   customized behaviour.
+#' @param allow_new_fields Whether to allow creation of new clio fields. Default
+#'   \code{FALSE} will produce an error encouraging you to check the field
+#'   names.
 #' @param ... Additional parameters passed to \code{pbapply::\link{pbsapply}}
 #'
 #' @return \code{NULL} invisibly on success. Errors out on failure.
@@ -283,6 +286,7 @@ parse_query <- function(query, version) {
 #' }
 manc_annotate_body <- function(x, test=TRUE, version=NULL,
                                write_empty_fields=FALSE,
+                               allow_new_fields=FALSE,
                                designated_user=NULL,
                                protect=c("user"), chunksize=50, query=TRUE, ...) {
   query=parse_query(query, version=version)
@@ -295,6 +299,14 @@ manc_annotate_body <- function(x, test=TRUE, version=NULL,
   fafbseg:::check_package_available('purrr')
   if(!is.character(x)) {
     if(is.data.frame(x)) {
+      cf=clio_fields()
+      new_fields=setdiff(colnames(x), cf)
+      if(isFALSE(allow_new_fields)) {
+        if(length(new_fields)>0)
+          stop("If you are sure you want to add new fields: \n    ",
+               paste(new_fields, collapse = ', '),
+               "\nafter appropriate discussion then please set `allow_new_fields=TRUE`")
+      }
       x <- clioannotationdf2list(x, write_empty_fields = write_empty_fields)
       if (length(x) > 0)
         x <- compute_clio_delta(x, test = test, write_empty_fields = write_empty_fields)

--- a/man/manc_annotate_body.Rd
+++ b/man/manc_annotate_body.Rd
@@ -9,6 +9,7 @@ manc_annotate_body(
   test = TRUE,
   version = NULL,
   write_empty_fields = FALSE,
+  allow_new_fields = FALSE,
   designated_user = NULL,
   protect = c("user"),
   chunksize = 50,
@@ -34,6 +35,10 @@ fields in the clio-store database (when they are not protected by the
 fields to an empty value (usually the empty string) then you must set
 \code{write_empty_fields=TRUE}.}
 
+\item{allow_new_fields}{Whether to allow creation of new clio fields. Default
+\code{FALSE} will produce an error encouraging you to check the field
+names.}
+
 \item{designated_user}{Optional email address when one person is uploading
 annotations on behalf of another user. See \bold{Users} section for
 details.}
@@ -51,7 +56,7 @@ Set to \code{Inf} to insist that all records are sent in a single request.
 
 \item{query}{Special query to pass to Clio API. If TRUE, then the default is
 passed with Clio version, FALSE means no query, and list is allowed for a
-customized behavior.}
+customized behaviour.}
 
 \item{...}{Additional parameters passed to \code{pbapply::\link{pbsapply}}}
 }

--- a/tests/testthat/test-annotations.R
+++ b/tests/testthat/test-annotations.R
@@ -24,3 +24,8 @@ test_that("parse_query", {
   expect_equal(res$version, "v9.9.9")
   expect_true("abc" %in% names(res))
 })
+
+test_that("new field check", {
+  df=data.frame(bodyid=10002, new_field='rhubarb', new_field2='crumble')
+  expect_error(manc_annotate_body(df, allow_new_fields = FALSE))
+})


### PR DESCRIPTION
* allow_new_fields defaults to FALSE
* if new fields are spotted then checks value of allow_new_fields
* includes test